### PR TITLE
allow connecting via wss://

### DIFF
--- a/src/adapters/buttplug.ts
+++ b/src/adapters/buttplug.ts
@@ -47,7 +47,11 @@ export function makeClient(
     connector = new instance.ButtplugEmbeddedConnectorOptions();
   } else {
     const c = new instance.ButtplugWebsocketConnectorOptions();
-    c.Address = `ws://${config.connection}`;
+    if (config.connection.startsWith("ws://") || config.connection.startsWith("wss://")) {
+      c.Address = config.connection;
+    } else {
+      c.Address = `ws://${config.connection}`;
+    }
     connector = c;
   }
   console.log("Created new Client ", config);


### PR DESCRIPTION
at least in Firefox, the browser will refuse to connect to a ws:// address if the page is served via https://